### PR TITLE
增加kepler API测试记录；验证获取到的qsc和qcp证书是否可用

### DIFF
--- a/testcase/key/公私钥生成.md
+++ b/testcase/key/公私钥生成.md
@@ -1,0 +1,82 @@
+# 生成公私钥
+
+    公私钥生成，服务端不保存
+
+## Parameters
+
+    NO Parameters
+
+## Responses
+
+   Response content type ： application/json
+
+### Curl
+
+内网服务ip地址：192.168.1.220
+上线使用域名：xxx.xxx.xx
+
+    curl -X GET "http://192.168.1.220/kepler/key/gen" -H "accept: application/json"
+
+### Request URL
+
+    http://192.168.1.220/kepler/key/gen
+
+### Server response
+
+    code:200
+    
+    Response body:
+    {
+      "code": 0,
+      "message": "请将privKey和pubKey部分内容分别存放为.pri和.pub文件，JSON格式，注意要去除空格",
+      "data": {
+        "privKey": {
+          "type": "tendermint/PrivKeyEd25519",
+          "value": "H7+ytyCIRt+BnY/6c2+LaMdFwGrSm35PS2yGXcJjTfYNX2E5Lk2wQjx2Sr3pNQ/4UdeH05bGycWc3pcAUSwtcQ=="
+        },
+        "pubKey": {
+          "type": "tendermint/PubKeyEd25519",
+          "value": "DV9hOS5NsEI8dkq96TUP+FHXh9OWxsnFnN6XAFEsLXE="
+        }
+      }
+    }
+    
+    Response headers:
+     access-control-allow-methods: POST, GET, HEAD, OPTIONS, PUT, PATCH, DELETE 
+     access-control-allow-origin: * 
+     connection: keep-alive 
+     content-length: 499 
+     content-type: application/json; charset=utf-8 
+     date: Fri, 09 Aug 2019 07:34:50 GMT 
+     server: openresty/1.13.6.2 
+
+## result
+
+将公钥和私钥信息进行保存：
+
+私钥保存：新建文件pri.json，文件内容如下
+
+    {
+        "type": "tendermint/PrivKeyEd25519",
+        "value": "H7+ytyCIRt+BnY/6c2+LaMdFwGrSm35PS2yGXcJjTfYNX2E5Lk2wQjx2Sr3pNQ/4UdeH05bGycWc3pcAUSwtcQ=="
+    }
+
+公钥保存：新建文件pub.json，文件内容如下
+
+    {
+         "type": "tendermint/PubKeyEd25519",
+         "value": "DV9hOS5NsEI8dkq96TUP+FHXh9OWxsnFnN6XAFEsLXE="
+    }
+
+使用私钥进行本地密钥库导入操作：
+
+    # ls
+    pri.json  go1.12.5.linux-amd64.tar.gz
+    # qoscli keys import abc --file pri.json 
+    > Enter a passphrase for your key:
+    > Repeat the passphrase:
+    # qoscli keys list
+    NAME: TYPE:  ADDRESS:           PUBKEY:
+    abc import  address10ya5d8a5vy5acrqtylk6nukh6a8kza0vj54keg      DV9hOS5NsEI8dkq96TUP+FHXh9OWxsnFnN6XAFEsLXE=
+
+导入的账户abc，公钥字段与我们之前生成的公钥一致，说明我们生成公私钥正确。

--- a/testcase/qcp/联盟链证书审核.md
+++ b/testcase/qcp/联盟链证书审核.md
@@ -1,0 +1,48 @@
+# 联盟链证书审核
+
+## Parameters
+
+| Name | required | type | Description | value |
+|--|--|--|--|--|
+| id |yes|integer| 申请id | 5 |
+| status |yes|integer| 状态设置：<br>1=发放证书；2=申请无效 | 1：发放证书 |
+
+## Responses
+
+   Response content type ： application/json
+
+### Curl
+
+内网服务ip地址：192.168.1.220
+
+上线使用域名：xxx.xxx.xx
+
+    curl -X PUT "http://192.168.1.220/kepler/qcp/apply/{id}?id=5&status=1" -H "accept: application/json"
+
+### Request URL
+
+    http://192.168.1.220/kepler/qcp/apply/%7Bid%7D?id=5&status=1
+
+### Server response
+
+    code:200
+    
+    Response body:
+    {
+    "code": 0,
+    "message": "success",
+    "data": 1
+    }
+    
+    Response headers:
+    access-control-allow-methods: POST, GET, HEAD, OPTIONS, PUT, PATCH, DELETE 
+    access-control-allow-origin: * 
+    connection: keep-alive 
+    content-length: 39 
+    content-type: application/json; charset=utf-8 
+    date: Fri, 09 Aug 2019 08:43:05 GMT 
+    server: openresty/1.13.6.2 
+
+## result
+
+审核操作由证书发放人员来完成，审核通过后，会向申请人邮箱发送证书信息。

--- a/testcase/qcp/联盟链证书查询.md
+++ b/testcase/qcp/联盟链证书查询.md
@@ -1,0 +1,95 @@
+# 联盟链证书查询
+
+## Parameters
+
+| Name | required | type | Description | value |
+|--|--|--|--|--|
+| phone |yes|string| 手机号 | 18511112222 |
+| email |yes|string| 邮箱 | wangkuan.zzu@qq.com |
+
+## Responses
+
+   Response content type ： application/json
+
+### Curl
+
+内网服务ip地址：192.168.1.220
+
+上线使用域名：xxx.xxx.xx
+
+    curl -X GET "http://192.168.1.220/kepler/qcp/apply?phone=18511112222&email=wangkuan.zzu%40qq.com" -H "accept: application/json"
+
+### Request URL
+
+    http://192.168.1.220/kepler/qcp/apply?phone=18511112222&email=wangkuan.zzu%40qq.com
+
+### Server response
+
+    code:200
+    
+    Response body:
+    {
+    "code": 0,
+    "message": "success",
+    "data": [
+        {
+        "id": 5,
+        "qcpChainId": "qcp-001",
+        "qosChainId": "capricorn-3000",
+        "qcpPub": "{ \"type\": \"tendermint/PubKeyEd25519\", \"value\": \"rkF5l4LCb28oaIBAYLb+H+O4/BrJ8fjYK+akWX2Hw6s=\"}",
+        "email": "wangkuan.zzu@qq.com",
+        "phone": "18511112222",
+        "info": "no info",
+        "createTime": "2019-08-09T16:28:19+08:00",
+        "updateTime": "2019-08-09T16:28:19+08:00",
+        "status": 1,
+        "note": ""
+        }
+    ]
+    }
+    
+    Response headers:
+    access-control-allow-methods: POST, GET, HEAD, OPTIONS, PUT, PATCH, DELETE 
+    access-control-allow-origin: * 
+    connection: keep-alive 
+    content-length: 583 
+    content-type: application/json; charset=utf-8 
+    date: Fri, 09 Aug 2019 08:33:12 GMT 
+    server: openresty/1.13.6.2 
+
+## result
+
+查询得到申请状态。
+|name|description|
+|--|--|
+|status|0：等待审核；<br>1：审核通过，发放证书；<br>2：申请无效。|
+|note|审核意见|
+
+证书信息可通过邮件查看。登录申请证书使用的邮箱，查看邮件。
+
+    //邮件主题
+    qcp crt for qcp-001 in capricorn-3000
+
+    //邮件内容
+    {"csr":{"subj":{"type":"certificate/QCPSubject","value":{"chain_id":"capricorn-3000","qcp_chain":"qcp-001"}},"is_ca":false,"not_before":"2019-08-09T08:43:05.463755946Z","not_after":"2020-08-09T08:43:05.463762459Z","public_key":{"type":"tendermint/PubKeyEd25519","value":"rkF5l4LCb28oaIBAYLb+H+O4/BrJ8fjYK+akWX2Hw6s="}},"ca":{"subj":null,"public_key":{"type":"tendermint/PubKeyEd25519","value":"w+UlkkcrHKKwAmEEl76rO5xHHj3quoxLgN5rvE5yYQ0="}},"signature":"NoK1Ix/wbnIELN0n+Dg//7RH+cPCQBe3uS0oFMRqt7KSz4wu5Lv6iSj3HKgvlFjMkT2DlWJlY19p+hlzXg0JAA=="}
+
+将邮件内容保存文件：qcp.crt，使用该文件在QOS网络中初始化联盟链信息
+
+    # ls
+    pri.json   qcp.crt   redis-5.0.4.tar.gz
+
+    # qoscli tx init-qcp --creator jlgy01 --qcp.crt qcp.crt
+    Password to sign with 'jlgy01':
+    {"check_tx":{"gasWanted":"100000","gasUsed":"8991"},"deliver_tx":{"gasWanted":"100000","gasUsed":"16160","tags":[{"key":"YWN0aW9u","value":"aW5pdC1xY3A="},{"key":"cWNw","value":"cWNwLTAwMQ=="},{"key":"Y3JlYXRvcg==","value":"YWRkcmVzczFubnZkcWVmdmE4OXh3cHB6czQ2dnVza2NrcjdrbHZ6azhyNXVhYQ=="}]},"hash":"4ABFDA14989B63F43A94C755716D4ECDC05BC8CAB74D768B746C419048412920","height":"633314"}
+
+    qoscli query qcp list
+    |Chain      |Type |MaxSequence |
+    |-----      |---- |----------- |
+    |qcp-001    |in   |0           |
+    |qcp-rocket |in   |1           |
+    |qcp-star   |in   |0           |
+    |qcp-001    |out  |0           |
+    |qcp-rocket |out  |1           |
+    |qcp-star   |out  |0           |
+
+通过使用qoscli query qcp命令来确认使用申请的qcp证书，初始化联盟链成功。

--- a/testcase/qcp/联盟链证书查询.md
+++ b/testcase/qcp/联盟链证书查询.md
@@ -60,6 +60,7 @@
 ## result
 
 查询得到申请状态。
+
 |name|description|
 |--|--|
 |status|0：等待审核；<br>1：审核通过，发放证书；<br>2：申请无效。|

--- a/testcase/qcp/联盟链证书申请.md
+++ b/testcase/qcp/联盟链证书申请.md
@@ -1,0 +1,52 @@
+# 联盟链证书申请
+
+## Parameters
+
+| Name | required | type | Description | value |
+|--|--|--|--|--|
+| qcpChainId |yes|string| 联盟链ChainId | qcp-001 |
+| qosChainId |yes|string| 公链ChainId | capricorn-3000 |
+| qcpPub |yes|string| QCP公钥 | { "type": "tendermint/PubKeyEd25519", "value": "rkF5l4LCb28oaIBAYLb+H+O4/BrJ8fjYK+akWX2Hw6s="} |
+| phone |yes|string| 手机号 | 18511112222 |
+| email |yes|string| 邮箱 | wangkuan.zzu@qq.com |
+| info |yes|string| 申请说明 | no info |
+
+## Responses
+
+   Response content type ： application/json
+
+### Curl
+
+内网服务ip地址：192.168.1.220
+
+上线使用域名：xxx.xxx.xx
+
+    curl -X POST "http://192.168.1.220/kepler/qcp/apply?qcpChainId=qcp-001&qosChainId=capricorn-3000&qcpPub=%7B%20%22type%22%3A%20%22tendermint%2FPubKeyEd25519%22%2C%20%22value%22%3A%20%22rkF5l4LCb28oaIBAYLb%2BH%2BO4%2FBrJ8fjYK%2BakWX2Hw6s%3D%22%7D&phone=18511112222&email=wangkuan.zzu%40qq.com&info=no%20info" -H "accept: application/json"
+
+### Request URL
+
+    http://192.168.1.220/kepler/qcp/apply?qcpChainId=qcp-001&qosChainId=capricorn-3000&qcpPub=%7B%20%22type%22%3A%20%22tendermint%2FPubKeyEd25519%22%2C%20%22value%22%3A%20%22rkF5l4LCb28oaIBAYLb%2BH%2BO4%2FBrJ8fjYK%2BakWX2Hw6s%3D%22%7D&phone=18511112222&email=wangkuan.zzu%40qq.com&info=no%20info
+
+### Server response
+
+    code:200
+    
+    Response body:
+    {
+        "code": 0,
+        "message": "success",
+        "data": 1
+    }
+    
+    Response headers:
+    access-control-allow-methods: POST, GET, HEAD, OPTIONS, PUT, PATCH, DELETE 
+    access-control-allow-origin: * 
+    connection: keep-alive 
+    content-length: 39 
+    content-type: application/json; charset=utf-8 
+    date: Fri, 09 Aug 2019 08:28:19 GMT 
+    server: openresty/1.13.6.2 
+
+## result
+
+完成申请后，等待审核，在审核期间可以进行进度查询。

--- a/testcase/qsc/联盟币证书审核.md
+++ b/testcase/qsc/联盟币证书审核.md
@@ -1,0 +1,48 @@
+# 联盟币证书审核
+
+## Parameters
+
+| Name | required | type | Description | value |
+|--|--|--|--|--|
+| id |yes|integer| 申请id | 3 |
+| status |yes|integer| 状态设置：<br>1=发放证书；2=申请无效 | 1 |
+
+## Responses
+
+   Response content type ： application/json
+
+### Curl
+
+内网服务ip地址：192.168.1.220
+
+上线使用域名：xxx.xxx.xx
+
+    curl -X PUT "http://192.168.1.220/kepler/qsc/apply/{id}?id=3&status=1" -H "accept: application/json"
+
+### Request URL
+
+    http://192.168.1.220/kepler/qsc/apply/%7Bid%7D?id=3&status=1
+
+### Server response
+
+    code:200
+    
+    Response body:
+    {
+    "code": 0,
+    "message": "success",
+    "data": 1
+    }
+    
+    Response headers:
+    access-control-allow-methods: POST, GET, HEAD, OPTIONS, PUT, PATCH, DELETE 
+    access-control-allow-origin: * 
+    connection: keep-alive 
+    content-length: 39 
+    content-type: application/json; charset=utf-8 
+    date: Fri, 09 Aug 2019 09:25:06 GMT 
+    server: openresty/1.13.6.2 
+
+## result
+
+审核操作由证书发放人员来完成，审核通过后，会向申请人邮箱发送证书信息。

--- a/testcase/qsc/联盟币证书查询.md
+++ b/testcase/qsc/联盟币证书查询.md
@@ -61,6 +61,7 @@
 ## result
 
 查询得到申请状态。
+
 |name|description|
 |--|--|
 |status|0：等待审核；<br>1：审核通过，发放证书；<br>2：申请无效。|

--- a/testcase/qsc/联盟币证书查询.md
+++ b/testcase/qsc/联盟币证书查询.md
@@ -1,0 +1,101 @@
+# 联盟币证书查询
+
+## Parameters
+
+| Name | required | type | Description | value |
+|--|--|--|--|--|
+| phone |yes|string| 手机号 | 18511112222 |
+| email |yes|string| 邮箱 | wangkuan.zzu@qq.com |
+
+## Responses
+
+   Response content type ： application/json
+
+### Curl
+
+内网服务ip地址：192.168.1.220
+
+上线使用域名：xxx.xxx.xx
+
+    curl -X GET "http://192.168.1.220/kepler/qcp/apply?phone=18511112222&email=wangkuan.zzu%40qq.com" -H "accept: application/json"
+
+### Request URL
+
+    http://192.168.1.220/kepler/qcp/apply?phone=18511112222&email=wangkuan.zzu%40qq.com
+
+### Server response
+
+    code:200
+    
+    Response body:
+    {
+    "code": 0,
+    "message": "success",
+    "data": [
+        {
+        "id": 3,
+        "qscName": "ZZU",
+        "qosChainId": "capricorn-3000",
+        "qscPub": "{\"type\": \"tendermint/PubKeyEd25519\", \"value\": \"VHJoLrCl4r3TuCHqVbbTHtjAVAJ72Ug56eP/pKoHI1U=\"}",
+        "bankerPub": "{\"type\": \"tendermint/PubKeyEd25519\", \"value\": \"DV9hOS5NsEI8dkq96TUP+FHXh9OWxsnFnN6XAFEsLXE=\"}",
+        "email": "wangkuan.zzu@qq.com",
+        "phone": "18511112222",
+        "info": "no info",
+        "createTime": "2019-08-09T17:17:56+08:00",
+        "updateTime": "2019-08-09T17:17:56+08:00",
+        "status": 0,
+        "note": ""
+        }
+    ]
+    }
+    
+    Response headers:
+    access-control-allow-methods: POST, GET, HEAD, OPTIONS, PUT, PATCH, DELETE 
+    access-control-allow-origin: * 
+    connection: keep-alive 
+    content-length: 705 
+    content-type: application/json; charset=utf-8 
+    date: Fri, 09 Aug 2019 09:19:26 GMT 
+    server: openresty/1.13.6.2
+
+## result
+
+查询得到申请状态。
+|name|description|
+|--|--|
+|status|0：等待审核；<br>1：审核通过，发放证书；<br>2：申请无效。|
+|note|审核意见|
+
+证书信息可通过邮件查看。登录申请证书使用的邮箱，查看邮件。
+
+    //邮件主题
+    qsc crt for ZZU in capricorn-3000
+
+    //邮件内容
+    {"csr":{"subj":{"type":"certificate/QSCSubject","value":{"chain_id":"capricorn-3000","name":"ZZU","banker":{"type":"tendermint/PubKeyEd25519","value":"DV9hOS5NsEI8dkq96TUP+FHXh9OWxsnFnN6XAFEsLXE="}}},"is_ca":false,"not_before":"2019-08-09T09:25:06.834290863Z","not_after":"2020-08-09T09:25:06.83429926Z","public_key":{"type":"tendermint/PubKeyEd25519","value":"VHJoLrCl4r3TuCHqVbbTHtjAVAJ72Ug56eP/pKoHI1U="}},"ca":{"subj":null,"public_key":{"type":"tendermint/PubKeyEd25519","value":"w+UlkkcrHKKwAmEEl76rO5xHHj3quoxLgN5rvE5yYQ0="}},"signature":"8TuPU+WFvL8kLc22+J9TR4Ebyjw7pS3jAzR4YqpJ4taVgEj4UizblEd2+xlgtI6Dk1YQOj9CV5XMUjR/9jaeDw=="}
+
+将邮件内容保存文件：qsc.crt
+
+    //创建联盟币
+    # qoscli tx create-qsc --creator jlgy01 --qsc.crt qsc.crt
+    Password to sign with 'jlgy01':
+    {"check_tx":{"gasWanted":"100000","gasUsed":"8991"},"deliver_tx":{"gasWanted":"100000","gasUsed":"16300","tags":[{"key":"YWN0aW9u","value":"Y3JlYXRlLXFzYw=="},{"key":"cXNj","value":"WlpV"},{"key":"Y3JlYXRvcg==","value":"YWRkcmVzczFubnZkcWVmdmE4OXh3cHB6czQ2dnVza2NrcjdrbHZ6azhyNXVhYQ=="}]},"hash":"9BCB871C6143B91AE25DAB1E97E2DEE08503149F5CCE69336178EBEEA480A103","height":"633853"}
+
+    //验证使用生成的证书创建联盟币是否成功
+    qoscli query qsc ZZU --indent
+    {
+    "name": "ZZU",
+    "chain_id": "capricorn-3000",
+    "extrate": "1",
+    "description": "",
+    "banker": "address10ya5d8a5vy5acrqtylk6nukh6a8kza0vj54keg"
+    }
+
+    //增发联盟币
+    # qoscli tx issue-qsc --qsc-name ZZU --banker jlgy04 --amount 10000000000
+    Password to sign with 'jlgy04':
+    {"check_tx":{"gasWanted":"100000","gasUsed":"6811"},"deliver_tx":{"gasWanted":"100000","gasUsed":"13080","tags":[{"key":"YWN0aW9u","value":"aXNzdWUtcXNj"},{"key":"cXNj","value":"WlpV"},{"key":"YmFua2Vy","value":"YWRkcmVzczEweWE1ZDhhNXZ5NWFjcnF0eWxrNm51a2g2YThremEwdmo1NGtlZw=="}]},"hash":"8A7DA0D6FCFD6F65A84DCCC496037DAB9DB97AEBE94DAE2071361C2F79CF7547","height":"634197"}
+
+    //增发联盟币查询
+    # qoscli query account jlgy04
+    {"type":"qos/types/QOSAccount","value":{"base_account":{"account_address":"address10ya5d8a5vy5acrqtylk6nukh6a8kza0vj54keg","public_key":{"type":"tendermint/PubKeyEd25519","value":"DV9hOS5NsEI8dkq96TUP+FHXh9OWxsnFnN6XAFEsLXE="},"nonce":"2"},"qos":"999998692","qscs":[{"coin_name":"ZZU","amount":"10000000000"}]}}

--- a/testcase/qsc/联盟币证书申请.md
+++ b/testcase/qsc/联盟币证书申请.md
@@ -1,0 +1,53 @@
+# 联盟币证书申请
+
+## Parameters
+
+| Name | required | type | Description | value |
+|--|--|--|--|--|
+| qscName |yes|string| 联盟币名称 | zzu |
+| qosChainId |yes|string| 公链ChainId | capricorn-3000 |
+| qscPub |yes|string| QSC公钥 | {"type": "tendermint/PubKeyEd25519", "value": "VHJoLrCl4r3TuCHqVbbTHtjAVAJ72Ug56eP/pKoHI1U="} |
+| bankerPub|yes|string|用于接收联盟币的账户公钥|{"type": "tendermint/PubKeyEd25519", "value": "DV9hOS5NsEI8dkq96TUP+FHXh9OWxsnFnN6XAFEsLXE="}|
+| phone |yes|string| 手机号 | 18511112222 |
+| email |yes|string| 邮箱 | wangkuan.zzu@qq.com |
+| info |yes|string| 申请说明 | no info |
+
+## Responses
+
+   Response content type ： application/json
+
+### Curl
+
+内网服务ip地址：192.168.1.220
+
+上线使用域名：xxx.xxx.xx
+
+    curl -X POST "http://192.168.1.220/kepler/qsc/apply?qscName=zzu&qosChainId=capricorn-3000&qscPub=%7B%22type%22%3A%20%22tendermint%2FPubKeyEd25519%22%2C%20%22value%22%3A%20%22VHJoLrCl4r3TuCHqVbbTHtjAVAJ72Ug56eP%2FpKoHI1U%3D%22%7D&bankerPub=%7B%22type%22%3A%20%22tendermint%2FPubKeyEd25519%22%2C%20%22value%22%3A%20%22DV9hOS5NsEI8dkq96TUP%2BFHXh9OWxsnFnN6XAFEsLXE%3D%22%7D&phone=18511112222&email=wangkuan.zzu%40qq.com&info=no%20info" -H "accept: application/json"
+
+### Request URL
+
+    http://192.168.1.220/kepler/qsc/apply?qscName=zzu&qosChainId=capricorn-3000&qscPub=%7B%22type%22%3A%20%22tendermint%2FPubKeyEd25519%22%2C%20%22value%22%3A%20%22VHJoLrCl4r3TuCHqVbbTHtjAVAJ72Ug56eP%2FpKoHI1U%3D%22%7D&bankerPub=%7B%22type%22%3A%20%22tendermint%2FPubKeyEd25519%22%2C%20%22value%22%3A%20%22DV9hOS5NsEI8dkq96TUP%2BFHXh9OWxsnFnN6XAFEsLXE%3D%22%7D&phone=18511112222&email=wangkuan.zzu%40qq.com&info=no%20info
+
+### Server response
+
+    code:200
+    
+    Response body:
+    {
+    "code": 0,
+    "message": "success",
+    "data": 1
+    }
+    
+    Response headers:
+     access-control-allow-methods: POST, GET, HEAD, OPTIONS, PUT, PATCH, DELETE 
+    access-control-allow-origin: * 
+    connection: keep-alive 
+    content-length: 39 
+    content-type: application/json; charset=utf-8 
+    date: Fri, 09 Aug 2019 09:17:56 GMT 
+    server: openresty/1.13.6.2
+
+## result
+
+完成申请后，等待审核，在审核期间可以进行进度查询。


### PR DESCRIPTION
1、kepler API正常操作调用测试记录；
2、通过kepler获取的公私钥，qsc和qcp证书，其可用性验证。
3、测试地址：http://192.168.1.220/kepler/swagger/index.html